### PR TITLE
Replace Mutable Default Parameters

### DIFF
--- a/Oil Money project/oil production/oil production cost curve.py
+++ b/Oil Money project/oil production/oil production cost curve.py
@@ -16,10 +16,13 @@ import pandas as pd
 
 #traditional commodity cost curve
 #input two pandas series, the third one is optional
-def cost_curve(x,y1,y2=[],
+def cost_curve(x,y1,y2=None,
                hline_var=0,hline_color='k',hline_name='',
-               colormap='tab20c',legends=[],notes=[],
+               colormap='tab20c',legends=None,notes=None,
                ylabel='',xlabel='',title='',fig_size=(10,5)):
+    y2 = [] if y2 is None else y2
+    legends = [] if legends is None else legends
+    notes = [] if notes is None else notes
     
     ax=plt.figure(figsize=fig_size).add_subplot(111)
     ax.spines['top'].set_visible(False)


### PR DESCRIPTION
Using mutable values for default arguments is not a safe practice.
Look at the following very simple example code:

```python
def foo(x, y=[]):
    y.append(x)
    print(y)
```

The function `foo` doesn't do anything very interesting; it just prints the result of `x` appended to `y`. Naively we might expect this to simply print an array containing only `x` every time `foo` is called, like this:

```python
>>> foo(1)
[1]
>>> foo(2)
[2]
```

But that's not what happens!

```python
>>> foo(1)
[1]
>>> foo(2)
[1, 2]
```

The value of `y` is preserved between calls! This might seem surprising, and it is. It's due to the way that scope works for function arguments in Python.

The result is that any default argument value will be preserved between function calls. This is problematic for *mutable* types, including things like `list`, `dict`, and `set`.

Relying on this behavior is unpredictable and generally considered to be unsafe. Most of us who write code like this were not anticipating the surprising behavior, so it's best to fix it.

Our codemod makes an update that looks like this:
```diff
- def foo(x, y=[]):
+ def foo(x, y=None):
+   y = [] if y is None else y
    y.append(x)
    print(y)
```

Using `None` is a much safer default. The new code checks if `None` is passed, and if so uses an empty `list` for the value of `y`. This will guarantee consistent and safe behavior between calls.

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/fix-mutable-params](https://docs.pixee.ai/codemods/python/pixee_python_fix-mutable-params)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fquant-trading%7Cd55493dac8c5767e6b689226a37572d9630f2567)

<!--{"type":"DRIP","codemod":"pixee:python/fix-mutable-params"}-->