### PR TITLE
Refactor: Implemented Modular Vectorized Backtesting Engine (OOP)

### DIFF
--- a/archive/MACD Oscillator backtest.py
+++ b/archive/MACD Oscillator backtest.py
@@ -141,3 +141,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/core/backtester.py
+++ b/core/backtester.py
@@ -1,0 +1,98 @@
+# core/backtester.py
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from abc import ABC, abstractmethod
+from typing import Optional, Tuple, Dict
+
+class VectorizedBacktester(ABC):
+    """
+    A base class for vectorized backtesting of trading strategies.
+    
+    Attributes:
+        symbol (str): The ticker symbol.
+        data (pd.DataFrame): The market data (OHLCV).
+        tc (float): Transaction costs as a percentage (e.g., 0.001 for 0.1%).
+    """
+
+    def __init__(self, symbol: str, data: pd.DataFrame, tc: float = 0.0):
+        self.symbol = symbol
+        self.data = data.copy()
+        self.tc = tc
+        self.results = None
+
+    @abstractmethod
+    def generate_signals(self):
+        """
+        Logic to define 'signal' column. 1 for long, -1 for short, 0 for neutral.
+        Must be implemented by the child class.
+        """
+        pass
+
+    def run_backtest(self):
+        """
+        Executes the backtest engine.
+        """
+        if 'signal' not in self.data.columns:
+            self.generate_signals()
+        
+        # Calculate Returns
+        # Strategy Return = Signal(t-1) * Market Return(t)
+        self.data['market_return'] = np.log(self.data['Close'] / self.data['Close'].shift(1))
+        self.data['strategy_return'] = self.data['signal'].shift(1) * self.data['market_return']
+        
+        # Adjust for Transaction Costs (only when position changes)
+        trades = self.data['signal'].diff().fillna(0).abs()
+        self.data['strategy_return_net'] = self.data['strategy_return'] - (trades * self.tc)
+        
+        # Cumulative Returns
+        self.data['creturns_market'] = self.data['market_return'].cumsum().apply(np.exp)
+        self.data['creturns_strategy'] = self.data['strategy_return_net'].cumsum().apply(np.exp)
+        
+        self.results = self.data
+        return self.results
+
+    def get_performance_metrics(self) -> Dict[str, float]:
+        """
+        Calculates key financial metrics: Sharpe, Drawdown, CAGR.
+        """
+        if self.results is None:
+            self.run_backtest()
+            
+        strategy_rets = self.results['strategy_return_net']
+        
+        # Annualized Sharpe Ratio (assuming 252 trading days)
+        sharpe = np.sqrt(252) * strategy_rets.mean() / strategy_rets.std()
+        
+        # Max Drawdown
+        cum_rets = self.results['creturns_strategy']
+        running_max = cum_rets.cummax()
+        drawdown = (cum_rets - running_max) / running_max
+        max_drawdown = drawdown.min()
+        
+        # Total Return
+        total_return = cum_rets.iloc[-1] - 1
+        
+        metrics = {
+            "Sharpe Ratio": round(sharpe, 2),
+            "Max Drawdown": round(max_drawdown * 100, 2),
+            "Total Return (%)": round(total_return * 100, 2)
+        }
+        return metrics
+
+    def plot_results(self):
+        """
+        Visualizes the performance against the benchmark.
+        """
+        if self.results is None:
+            print("Run backtest first.")
+            return
+            
+        plt.figure(figsize=(12, 8))
+        plt.title(f"Backtest Results: {self.symbol}")
+        plt.plot(self.results['creturns_market'], label="Market (Buy & Hold)", alpha=0.6)
+        plt.plot(self.results['creturns_strategy'], label="Strategy (Net of Fees)", linewidth=2)
+        plt.legend()
+        plt.grid(True)
+        plt.show()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+# main.py
+
+import pandas as pd
+import yfinance as yf
+from strategies.macd_strategy import MACDStrategy
+
+def main():
+    # 1. Fetch Data
+    symbol = "AAPL"
+    print(f"Fetching data for {symbol}...")
+    df = yf.download(symbol, start="2020-01-01", end="2023-01-01", progress=False)
+    
+    # Check if data structure is multi-index (common with new yfinance) and flatten if needed
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+
+    # 2. Instantiate Strategy
+    # We add a transaction cost of 0.1% per trade (0.001) to be realistic
+    macd = MACDStrategy(symbol, df, short_window=12, long_window=26, signal_window=9, tc=0.001)
+
+    # 3. Run Engine
+    print("Running Backtest...")
+    macd.run_backtest()
+
+    # 4. Print "Top 1%" Metrics
+    metrics = macd.get_performance_metrics()
+    print("\n" + "="*30)
+    print(f" PERFORMANCE REPORT: {symbol}")
+    print("="*30)
+    for k, v in metrics.items():
+        print(f"{k:<20}: {v}")
+    print("="*30)
+
+    # 5. Plot
+    macd.plot_results()
+
+if __name__ == "__main__":
+    main()

--- a/strategies/macd_strategy.py
+++ b/strategies/macd_strategy.py
@@ -1,0 +1,37 @@
+# strategies/macd_strategy.py
+
+import pandas as pd
+import numpy as np
+from core.backtester import VectorizedBacktester
+
+class MACDStrategy(VectorizedBacktester):
+    """
+    Implements MACD Oscillator Strategy inheriting from VectorizedBacktester.
+    """
+    
+    def __init__(self, symbol: str, data: pd.DataFrame, short_window=12, long_window=26, signal_window=9, tc=0.0):
+        super().__init__(symbol, data, tc)
+        self.short_window = short_window
+        self.long_window = long_window
+        self.signal_window = signal_window
+
+    def generate_signals(self):
+        """
+        Specific logic for MACD.
+        """
+        data = self.data
+        
+        # Calculate EMAs
+        ema_short = data['Close'].ewm(span=self.short_window, adjust=False).mean()
+        ema_long = data['Close'].ewm(span=self.long_window, adjust=False).mean()
+        
+        # MACD Line & Signal Line
+        data['MACD'] = ema_short - ema_long
+        data['Signal_Line'] = data['MACD'].ewm(span=self.signal_window, adjust=False).mean()
+        
+        # Vectorized Signal Logic
+        # Long (1) when MACD > Signal Line
+        # Short (-1) when MACD < Signal Line
+        data['signal'] = np.where(data['MACD'] > data['Signal_Line'], 1, -1)
+        
+        self.data = data


### PR DESCRIPTION
I noticed the repository currently relies on standalone scripts with duplicated backtesting logic. To improve maintainability and scalability, I have introduced a unified VectorizedBacktester base class.

Key Changes:
- OOP Architecture: Created a base parent class VectorizedBacktester in core/ to handle PnL, transaction costs, and plotting.
- Performance: Switched from iterative loops to vectorized Pandas operations for faster execution.
- Standardization: Added a get_performance_metrics() method to standardize Sharpe/Drawdown reporting across all future strategies.
- Proof of Concept: Ported the MACD strategy to this new framework as a demonstration.